### PR TITLE
ScalaTest+EasyMock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.class
 *.log
+.idea/
+target/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # scalatestplus-easymock
  ScalaTest + EasyMock provides integration support between ScalaTest and EasyMock.
+
+**Publishing**
+
+Please use the following commands to publish to Sonatype: 
+
+```
+$ sbt +publishSigned
+```

--- a/build.sbt
+++ b/build.sbt
@@ -32,6 +32,28 @@ libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "3.1.0-SNAP8"
 )
 
+enablePlugins(SbtOsgi)
+
+osgiSettings
+
+OsgiKeys.exportPackage := Seq(
+  "org.scalatestplus.easymock.*"
+)
+
+OsgiKeys.importPackage := Seq(
+  "org.scalatest.*",
+  "org.scalactic.*", 
+  "scala.*;version=\"$<range;[==,=+);$<replace;"+scalaBinaryVersion.value+";-;.>>\"",
+  "*;resolution:=optional"
+)
+
+OsgiKeys.additionalHeaders:= Map(
+  "Bundle-Name" -> "ScalaTestPlusEasyMock",
+  "Bundle-Description" -> "ScalaTest+EasyMock is an open-source integration library between ScalaTest and EasyMock for Scala projects.",
+  "Bundle-DocURL" -> "http://www.scalatest.org/",
+  "Bundle-Vendor" -> "Artima, Inc."
+)
+
 publishTo := {
   val nexus = "https://oss.sonatype.org/"
   Some("publish-releases" at nexus + "service/local/staging/deploy/maven2")

--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,50 @@
+name := "scalatestplus-easymock"
+
+organization := "org.scalatestplus"
+
+version := "1.0.0-SNAP1"
+
+homepage := Some(url("https://github.com/scalatest/scalatestplus-easymock"))
+
+licenses := List("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0"))
+
+developers := List(
+  Developer(
+    "bvenners",
+    "Bill Venners",
+    "bill@artima.com",
+    url("https://github.com/bvenners")
+  ),
+  Developer(
+    "cheeseng",
+    "Chua Chee Seng",
+    "cheeseng@amaseng.com",
+    url("https://github.com/cheeseng")
+  )
+)
+
+crossScalaVersions := List("2.11.12", "2.12.8", "2.13.0-M5")
+
+resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"
+
+libraryDependencies ++= Seq(
+  "org.easymock" % "easymockclassextension" % "3.2",
+  "org.scalatest" %% "scalatest" % "3.1.0-SNAP7"
+)
+
+publishTo := {
+  val nexus = "https://oss.sonatype.org/"
+  Some("publish-releases" at nexus + "service/local/staging/deploy/maven2")
+}
+
+publishMavenStyle := true
+
+publishArtifact in Test := false
+
+pomIncludeRepository := { _ => false }
+
+credentials += Credentials(Path.userHome / ".ivy2" / ".credentials")
+
+pgpSecretRing := file((Path.userHome / ".gnupg" / "secring.gpg").getAbsolutePath)
+
+pgpPassphrase := None

--- a/build.sbt
+++ b/build.sbt
@@ -23,13 +23,13 @@ developers := List(
   )
 )
 
-crossScalaVersions := List("2.11.12", "2.12.8", "2.13.0-M5")
+crossScalaVersions := List("2.10.7", "2.11.12", "2.12.8", "2.13.0-M5")
 
 resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"
 
 libraryDependencies ++= Seq(
   "org.easymock" % "easymockclassextension" % "3.2",
-  "org.scalatest" %% "scalatest" % "3.1.0-SNAP7"
+  "org.scalatest" %% "scalatest" % "3.1.0-SNAP8"
 )
 
 publishTo := {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.2.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,3 @@
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.1")
+
+addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.2.2")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,5 @@
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.1")
 
 addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.2.2")
+
+addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.9.4")

--- a/src/main/scala/org/scalatestplus/easymock/EasyMockSugar.scala
+++ b/src/main/scala/org/scalatestplus/easymock/EasyMockSugar.scala
@@ -1,0 +1,507 @@
+/*
+ * Copyright 2001-2013 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalatestplus.easymock
+
+import org.easymock.IExpectationSetters
+import scala.reflect.ClassTag
+import org.easymock.EasyMock
+import org.easymock.EasyMock.{expect => easyMockExpect, expectLastCall}
+
+/**
+ * Trait that provides some basic syntax sugar for <a href="http://easymock.org/" target="_blank">EasyMock</a>.
+ *
+ * <p>
+ * Using the EasyMock API directly, you create a mock with:
+ * </p>
+ *
+ * <pre class="stHighlight">
+ * val mockCollaborator = createMock(classOf[Collaborator])
+ * </pre>
+ *
+ * <p>
+ * With this trait, you can shorten that to:
+ * </p>
+ *
+ * <pre class="stHighlight">
+ * val mockCollaborator = mock[Collaborator]
+ * </pre>
+ *
+ * <p>
+ * After creating mocks, you set expectations on them, using syntax like this:
+ * </p>
+ *
+ * <pre class="stHighlight">
+ * mockCollaborator.documentAdded("Document")
+ * mockCollaborator.documentChanged("Document")
+ * expectLastCall().times(3)
+ * </pre>
+ *
+ * <p>
+ * If you wish to highlight which statements are setting expectations on the mock (versus
+ * which ones are actually using the mock), you can place them in an <code>expecting</code>
+ * clause, provided by this trait, like this:
+ * </p>
+ *
+ * <pre class="stHighlight">
+ * expecting {
+ *   mockCollaborator.documentAdded("Document")
+ *   mockCollaborator.documentChanged("Document")
+ *   lastCall.times(3)
+ * }
+ * </pre>
+ *
+ * <p>
+ * Using an <code>expecting</code> clause is optional, because it does nothing but visually indicate
+ * which statements are setting expectations on mocks. (Note: this trait also provides the <code>lastCall</code>
+ * method, which just calls <code>expectLastCall</code>.)
+ * </p>
+ *
+ * <p>
+ * Once you've set expectations on the mock objects, you must invoke <code>replay</code> on
+ * the mocks to indicate you are done setting expectations, and will start using the mock.
+ * After using the mock, you must invoke <code>verify</code> to check to make sure the mock
+ * was used in accordance with the expectations you set on it. Here's how that looks when you
+ * use the EasyMock API directly:
+ * </p>
+ *
+ * <pre class="stHighlight">
+ * replay(mockCollaborator)
+ * classUnderTest.addDocument("Document", new Array[Byte](0))
+ * classUnderTest.addDocument("Document", new Array[Byte](0))
+ * classUnderTest.addDocument("Document", new Array[Byte](0))
+ * classUnderTest.addDocument("Document", new Array[Byte](0))
+ * verify(mockCollaborator)
+ * </pre>
+ *
+ * <p>
+ * This trait enables you to use the following, more declarative syntax instead:
+ * </p>
+ *
+ * <pre class="stHighlight">
+ * whenExecuting(mockCollaborator) {
+ *   classUnderTest.addDocument("Document", new Array[Byte](0))
+ *   classUnderTest.addDocument("Document", new Array[Byte](0))
+ *   classUnderTest.addDocument("Document", new Array[Byte](0))
+ *   classUnderTest.addDocument("Document", new Array[Byte](0))
+ * }
+ * </pre>
+ *
+ * <p>
+ * The <code>whenExecuting</code> method will pass the <code>mockCollaborator</code> to
+ * <code>replay</code>, execute the passed function (your code that uses the mock), and
+ * call <code>verify</code>, passing in the <code>mockCollaborator</code>. If you want to
+ * use multiple mocks, you can pass multiple mocks to <code>whenExecuting</code>.
+ * </p>
+ *
+ * <p>
+ * To summarize, here's what a typical test using <code>EasyMockSugar</code> looks like:
+ * </p>
+ *
+ * <pre class="stHighlight">
+ * val mockCollaborator = mock[Collaborator]
+ *
+ * expecting {
+ *   mockCollaborator.documentAdded("Document")
+ *   mockCollaborator.documentChanged("Document")
+ *   lastCall.times(3)
+ * }
+ *
+ * whenExecuting(mockCollaborator) {
+ *   classUnderTest.addDocument("Document", new Array[Byte](0))
+ *   classUnderTest.addDocument("Document", new Array[Byte](0))
+ *   classUnderTest.addDocument("Document", new Array[Byte](0))
+ *   classUnderTest.addDocument("Document", new Array[Byte](0))
+ * }
+ * </pre>
+ *
+ * <p>
+ * An alternative approach is to place your mock objects in a <code>MockObjects</code> holder object referenced
+ * from an implicit <code>val</code>, then use the overloaded variant of <code>whenExecuting</code> that
+ * takes an implicit <code>MockObjects</code> parameter. Here's how that would look:
+ * </p>
+ *
+ * <pre class="stHighlight">
+ * implicit val mocks = MockObjects(mock[Collaborator])
+ *
+ * expecting {
+ *   mockCollaborator.documentAdded("Document")
+ *   mockCollaborator.documentChanged("Document")
+ *   lastCall.times(3)
+ * }
+ *
+ * whenExecuting {
+ *   classUnderTest.addDocument("Document", new Array[Byte](0))
+ *   classUnderTest.addDocument("Document", new Array[Byte](0))
+ *   classUnderTest.addDocument("Document", new Array[Byte](0))
+ *   classUnderTest.addDocument("Document", new Array[Byte](0))
+ * }
+ * </pre>
+ *
+ * <p>
+ * Note: As of ScalaTest 1.3, this trait supports EasyMock 3, with no dependencies on EasyMock class extension.
+ * </p>
+ *
+ * @author Bill Venners
+ * @author George Berger
+ */
+trait EasyMockSugar {
+
+  import scala.language.implicitConversions
+
+  /**
+   * Implicit conversion that invokes the <code>expect</code> method on the <code>EasyMock</code> companion object (<em>i.e.</em>, the
+   * static <code>expect</code> method in Java class <code>org.easymock.EasyMock</code>).
+   *
+   * <p>
+   * In a ScalaTest <code>Suite</code>, the <code>expect</code> method defined in <code>Assertions</code>, and inherited by <code>Suite</code>,
+   * interferes with the <code>expect</code> method if imported from <code>EasyMock</code>. You can invoke it by qualifying it, <em>i.e.</em>,
+   * <code>EasyMock.expect</code>, or by changing its name on import, like this:
+   *
+   * <pre class="stHighlight">
+   * import org.easymock.EasyMock.{expect => easyMockExpect, _}
+   * </pre>
+   *
+   * <p>
+   * But if you mix in this trait, you can just invoke <code>call</code> instead.
+   * </p>
+   *
+   * <p>
+   * You can use this method, for example, to chain expectations like this:
+   * </p>
+   *
+   * <pre class="stHighlight">
+   * expecting {
+   *   call(mock.getName).andReturn("Ben Franklin")
+   * }
+   * </pre>
+   *
+   * <p>
+   * Note: the name of this methods is <code>call</code>, not <code>expectCall</code> because
+   * "expect" appears in the surrounding <code>expecting</code> clause provided by this trait.
+   * </p>
+   *
+   * <p>
+   * Moreover, because this method is marked <code>implicit</code>, you will usually be able to simply
+   * leave it off. So long as the result of the method call you are expecting doesn't have
+   * a method that satisfies the subsequent invocation (such as <code>andReturn</code> in this
+   * example), the Scala compiler will invoke <code>call</code> for you
+   * implicitly. Here's how that looks:
+   * </p>
+   *
+   * <pre class="stHighlight">
+   * expecting {
+   *   mock.getName.andReturn("Ben Franklin")
+   * }
+   * </pre>
+   *
+   * @param value - the result of invoking a method on mock prior to invoking <code>replay</code>.
+   */
+  implicit def call[T](value: T): IExpectationSetters[T] = easyMockExpect(value)
+
+  /**
+   * Invokes the <code>expectLastCall</code> method on the <code>EasyMock</code> companion object (<em>i.e.</em>, the
+   * static <code>expect</code> method in Java class <code>org.easymock.EasyMock</code>).
+   *
+   * <p>
+   * This method is provided simply to allow you to avoid repeating "expect" inside an
+   * <code>expecting</code> clause. Here's an example that uses the <code>expectLastCall</code> directly
+   * to express the expectation that the <code>getName</code> method will be invoked three times
+   * on a mock, each time returning <code>"Ben Franklin"</code>:
+   * </p>
+   *
+   * <pre class="stHighlight">
+   * expecting {
+   *   mock.getName.andReturn("Ben Franklin")
+   *   expectLastCall.times(3)
+   * }
+   * </pre>
+   *
+   * <p>
+   * Using this method, you can compress this to:
+   * </p>
+   *
+   * <pre class="stHighlight">
+   * expecting {
+   *   mock.getName.andReturn("Ben Franklin")
+   *   lastCall.times(3)
+   * }
+   * </pre>
+   */
+  def lastCall[T]: IExpectationSetters[T] = expectLastCall()
+
+  /**
+   * Invokes the <code>createMock</code> method on the <code>EasyMock</code> companion object (<em>i.e.</em>, the
+   * static <code>createMock</code> method in Java class <code>org.easymock.classextension.EasyMock</code>).
+   *
+   * <p>
+   * Using the EasyMock API directly, you create a mock with:
+   * </p>
+   *
+   * <pre class="stHighlight">
+   * val mockCollaborator = createMock(classOf[Collaborator])
+   * </pre>
+   *
+   * <p>
+   * Using this method, you can shorten that to:
+   * </p>
+   *
+   * <pre class="stHighlight">
+   * val mockCollaborator = mock[Collaborator]
+   * </pre>
+   */
+  def mock[T <: AnyRef](implicit classTag: ClassTag[T]): T = {
+    EasyMock.createMock(classTag.runtimeClass.asInstanceOf[Class[T]])
+  }
+
+  /**
+   * Invokes the <code>createStrictMock</code> method on the <code>EasyMock</code> companion object (<em>i.e.</em>, the
+   * static <code>createStrictMock</code> method in Java class <code>org.easymock.classextension.EasyMock</code>).
+   *
+   * <p>
+   * Using the EasyMock API directly, you create a strict mock with:
+   * </p>
+   *
+   * <pre class="stHighlight">
+   * val mockCollaborator = createStrictMock(classOf[Collaborator])
+   * </pre>
+   *
+   * <p>
+   * Using this trait, you can shorten that to:
+   * </p>
+   *
+   * <pre class="stHighlight">
+   * val mockCollaborator = strictMock[Collaborator]
+   * </pre>
+   */
+  def strictMock[T <: AnyRef](implicit classTag: ClassTag[T]): T = {
+    EasyMock.createStrictMock(classTag.runtimeClass.asInstanceOf[Class[T]])
+  }
+
+  /**
+   * Invokes the <code>createNiceMock</code> method on the <code>EasyMock</code> companion object (<em>i.e.</em>, the
+   * static <code>createNiceMock</code> method in Java class <code>org.easymock.classextension.EasyMock</code>).
+   *
+   * <p>
+   * Using the EasyMock API directly, you create a nice mock with:
+   * </p>
+   *
+   * <pre class="stHighlight">
+   * val mockCollaborator = createNiceMock(classOf[Collaborator])
+   * </pre>
+   *
+   * <p>
+   * Using this trait, you can shorten that to:
+   * </p>
+   *
+   * <pre class="stHighlight">
+   * val mockCollaborator = niceMock[Collaborator]
+   * </pre>
+   */
+  def niceMock[T <: AnyRef](implicit classTag: ClassTag[T]): T = {
+    EasyMock.createNiceMock(classTag.runtimeClass.asInstanceOf[Class[T]])
+  }
+
+  /**
+   * Provides a visual clue to readers of the code that a set of statements are expectations being
+   * set on mocks.
+   *
+   * <p>
+   * Using the EasyMock API directly, you set expectations on a mock object with syntax like:
+   * </p>
+   *
+   * <pre class="stHighlight">
+   * mockCollaborator.documentAdded("Document")
+   * mockCollaborator.documentChanged("Document")
+   * expectLastCall().times(3)
+   * </pre>
+   *
+   * <p>
+   * This <code>expecting</code> method can make it more obvious which portion of your test code
+   * is devoted to setting expectations on mock objects. For example:
+   * </p>
+   *
+   * <pre class="stHighlight">
+   * expecting {
+   *   mockCollaborator.documentAdded("Document")
+   *   mockCollaborator.documentChanged("Document")
+   *   lastCall.times(3)
+   * }
+   * </pre>
+   *
+   * <p>
+   * Using an <code>expecting</code> clause is optional, because it does nothing besides visually indicate
+   * which statements are setting expectations on mocks. Note: this trait also provides the <code>lastCall</code>
+   * method, which just calls <code>expectLastCall</code>. This allows you to avoid writing "expect" twice.
+   * Also, the reason <code>expecting</code> doesn't take a by-name parameter, execute that, then call
+   * <code>replay</code> is because you would then need to pass your mock object or objects into
+   * <code>expecting</code>. Since you already need to pass the mocks into <code>whenExecuting</code> so
+   * that <code>verify</code> can be invoked on them, it yields more concise client code to have
+   * <code>whenExecuting</code> invoke <code>replay</code> on the mocks first rather than having
+   * <code>expecting</code> invoke <code>replay</code> last.
+   * </p>
+   */
+  def expecting(unused: Any): Unit = ()
+
+  /**
+   * Invokes <code>replay</code> on the passed mock object or objects, executes the passed function, then invokes
+   * <code>verify</code> on the passed mock object or objects.
+   *
+   * <p>
+   * Once you've set expectations on some mock objects, you must invoke <code>replay</code> on
+   * the mocks to indicate you are done setting expectations, and will start using the mocks.
+   * After using the mocks, you must invoke <code>verify</code> to check to make sure the mocks
+   * were used in accordance with the expectations you set on it. Here's how that looks when you
+   * use the EasyMock API directly:
+   * </p>
+   *
+   *
+   * <pre class="stHighlight">
+   * replay(mock)
+   * classUnderTest.addDocument("Document", new Array[Byte](0))
+   * classUnderTest.addDocument("Document", new Array[Byte](0))
+   * classUnderTest.addDocument("Document", new Array[Byte](0))
+   * classUnderTest.addDocument("Document", new Array[Byte](0))
+   * verify(mock)
+   * </pre>
+   *
+   * <p>
+   * This method enables you to use the following, more declarative syntax instead:
+   * </p>
+   * 
+   * <pre class="stHighlight">
+   * whenExecuting(mockCollaborator) {
+   *   classUnderTest.addDocument("Document", new Array[Byte](0))
+   *   classUnderTest.addDocument("Document", new Array[Byte](0))
+   *   classUnderTest.addDocument("Document", new Array[Byte](0))
+   *   classUnderTest.addDocument("Document", new Array[Byte](0))
+   * }
+   * </pre>
+   *
+   * <p>
+   * If you are working with multiple mock objects at once, you simply pass
+   * them all to <code>whenExecuting</code>, like this:
+   * </p>
+   *
+   * <pre class="stHighlight">
+   * whenExecuting(mock1, mock2, mock3) {
+   *   // ...
+   * }
+   * </pre>
+   *
+   * <p>
+   * The <code>whenExecuting</code> method will first invoke <code>EasyMock.reply</code>
+   * once for each mock you supplied, execute the passed function, then
+   * invoke <code>EasyMock.verify</code> once for each mock you supplied. If an exception
+   * is thrown by the passed function, <code>whenExecuting</code> will complete abruptly with
+   * that same exception without executing verify on any of the mocks.
+   * </p>
+   *
+   * @param mocks one or more mock objects to invoke <code>replay</code> before using and <code>verify</code> after using.
+   * @throws IllegalArgumentException if no mocks are passed
+   */
+  def whenExecuting(mocks: AnyRef*)(fun: => Unit): Unit = {
+
+    require(mocks.length > 0, "Must pass at least one mock to whenExecuting, but mocks.length was 0.") 
+
+    for (m <- mocks)
+      EasyMock.replay(m)
+
+    fun
+
+    // Don't put this in a try block, so that if fun throws an exception 
+    // it propagates out immediately and shows up as the cause of the failed test
+    for (m <- mocks)
+      EasyMock.verify(m)
+  }
+
+  /**
+   * Holder class for a collection of mocks that can be passed implicitly to one form of the
+   * overloaded <code>whenExecuting</code> method.
+   *
+   * @param mocks one or more mock objects that you intend to pass to <code>whenExecuting</code>
+   * @throws IllegalArgumentException if no mocks are passed
+   */
+  case class MockObjects(mocks: AnyRef*) {
+    require(mocks.length > 0, "Must pass at least one mock to MockObjects constructor, but mocks.length was 0.") 
+  }
+
+  /**
+   * Invokes <code>replay</code> on the mock object or objects passed via an implicit parameter,
+   * executes the passed function, then invokes <code>verify</code> on the passed mock object or objects.
+   *
+   * <p>
+   * Once you've set expectations on some mock objects, you must invoke <code>replay</code> on
+   * the mocks to indicate you are done setting expectations, and will start using the mocks.
+   * After using the mocks, you must invoke <code>verify</code> to check to make sure the mocks
+   * were used in accordance with the expectations you set on it. Here's how that looks when you
+   * use the EasyMock API directly:
+   * </p>
+   *
+   *
+   * <pre class="stHighlight">
+   * replay(mock)
+   * classUnderTest.addDocument("Document", new Array[Byte](0))
+   * classUnderTest.addDocument("Document", new Array[Byte](0))
+   * classUnderTest.addDocument("Document", new Array[Byte](0))
+   * classUnderTest.addDocument("Document", new Array[Byte](0))
+   * verify(mock)
+   * </pre>
+   *
+   * <p>
+   * This method enables you to use the following, more declarative syntax instead:
+   * </p>
+   * 
+   * <pre class="stHighlight">
+   * implicit val mocks = MockObjects(mockCollaborator)
+   *
+   * whenExecuting {
+   *   classUnderTest.addDocument("Document", new Array[Byte](0))
+   *   classUnderTest.addDocument("Document", new Array[Byte](0))
+   *   classUnderTest.addDocument("Document", new Array[Byte](0))
+   *   classUnderTest.addDocument("Document", new Array[Byte](0))
+   * }
+   * </pre>
+   *
+   * <p>
+   * If you are working with multiple mock objects at once, you simply pass
+   * them all to <code>MockObjects</code>, like this:
+   * </p>
+   *
+   * <pre class="stHighlight">
+   * implicit val mocks = MockObjects(mock1, mock2, mock3)
+   * </pre>
+   *
+   * <p>
+   * The <code>whenExecuting</code> method will first invoke <code>EasyMock.reply</code>
+   * once for each mock you supplied, execute the passed function, then
+   * invoke <code>EasyMock.verify</code> once for each mock you supplied. If an exception
+   * is thrown by the passed function, <code>whenExecuting</code> will complete abruptly with
+   * that same exception without executing verify on any of the mocks.
+   * </p>
+   */
+  def whenExecuting(fun: => Unit)(implicit mocks: MockObjects): Unit = {
+    whenExecuting(mocks.mocks: _*)(fun)
+  }
+}
+
+/**
+ * Companion object that facilitates the importing of <code>EasyMockSugar</code> members as 
+ * an alternative to mixing it in. One use case is to import <code>EasyMockSugar</code> members so you can use
+ * them in the Scala interpreter.
+ */
+// TODO: Fill in an example
+object EasyMockSugar extends EasyMockSugar
+

--- a/src/test/scala/org/scalatestplus/easymock/EasyMockSugarSpec.scala
+++ b/src/test/scala/org/scalatestplus/easymock/EasyMockSugarSpec.scala
@@ -1,0 +1,419 @@
+/*
+ * Copyright 2001-2013 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalatestplus.easymock
+
+import org.scalatest._
+//import SharedHelpers._
+import refspec.RefSpec
+
+class EasyMockSugarSpec extends FlatSpec with Matchers {
+  "The EasyMockSugar trait's whenExecuting method" should
+          "work with multiple mocks passed in" in {
+    val a = new RefSpec with EasyMockSugar {
+      def `test that should fail`: Unit = {
+        trait OneFish {
+          def eat(food: String): Unit = ()
+        }
+        trait TwoFish {
+          def eat(food: String): Unit = ()
+        }
+        val oneFishMock = mock[OneFish]
+        val twoFishMock = mock[TwoFish]
+
+        expecting {
+          oneFishMock.eat("red fish")
+          twoFishMock.eat("blue fish")
+        }
+
+        // Trying the use case of passing an existing list of mocks for
+        // the heck of it.
+        val mocks = List(oneFishMock, twoFishMock)
+
+        whenExecuting(mocks: _*) {
+          oneFishMock.eat("red fish")
+          twoFishMock.eat("green fish")
+        }
+      }
+
+      def `test that should succeed`: Unit = {
+        trait OneFish {
+          def eat(food: String): Unit = ()
+        }
+        trait TwoFish {
+          def eat(food: String): Unit = ()
+        }
+        val oneFishMock = mock[OneFish]
+        val twoFishMock = mock[TwoFish]
+
+        expecting {
+          oneFishMock.eat("red fish")
+          twoFishMock.eat("blue fish")
+        }
+
+        whenExecuting(oneFishMock, twoFishMock) {
+          oneFishMock.eat("red fish")
+          twoFishMock.eat("blue fish")
+        }
+      }
+
+      def `test that should fail with class`: Unit = {
+        class OneFish {
+          def eat(food: String): Unit = ()
+        }
+        class TwoFish {
+          def eat(food: String): Unit = ()
+        }
+        val oneFishMock = mock[OneFish]
+        val twoFishMock = mock[TwoFish]
+
+        expecting {
+          oneFishMock.eat("red fish")
+          twoFishMock.eat("blue fish")
+        }
+
+        whenExecuting(oneFishMock, twoFishMock) {
+          oneFishMock.eat("red fish")
+          twoFishMock.eat("green fish")
+        }
+      }
+
+      def `test that should succeed with class`: Unit = {
+        class OneFish {
+          def eat(food: String): Unit = ()
+        }
+        class TwoFish {
+          def eat(food: String): Unit = ()
+        }
+        val oneFishMock = mock[OneFish]
+        val twoFishMock = mock[TwoFish]
+
+        expecting {
+          oneFishMock.eat("red fish")
+          twoFishMock.eat("blue fish")
+        }
+
+        whenExecuting(oneFishMock, twoFishMock) {
+          oneFishMock.eat("red fish")
+          twoFishMock.eat("blue fish")
+        }
+      }
+
+      def `test that should fail strict`: Unit = {
+        class OneFish {
+          def eat(food: String): Unit = ()
+          def burp(flavor: String): Unit = ()
+        }
+        class TwoFish {
+          def eat(food: String): Unit = ()
+        }
+        val oneFishMock = strictMock[OneFish]
+        val twoFishMock = strictMock[TwoFish]
+
+        expecting {
+          oneFishMock.eat("red fish")
+          oneFishMock.burp("red fish")
+          twoFishMock.eat("blue fish")
+        }
+
+        whenExecuting(oneFishMock, twoFishMock) {
+          oneFishMock.burp("red fish")
+          oneFishMock.eat("red fish")
+          twoFishMock.eat("blue fish")
+        }
+      }
+
+      def `test that should succeed strict`: Unit = {
+        class OneFish {
+          def eat(food: String): Unit = ()
+          def burp(flavor: String): Unit = ()
+        }
+        class TwoFish {
+          def eat(food: String): Unit = ()
+        }
+        val oneFishMock = strictMock[OneFish]
+        val twoFishMock = strictMock[TwoFish]
+
+        expecting {
+          oneFishMock.eat("red fish")
+          oneFishMock.burp("red fish")
+          twoFishMock.eat("blue fish")
+        }
+
+        whenExecuting(oneFishMock, twoFishMock) {
+          oneFishMock.eat("red fish")
+          oneFishMock.burp("red fish")
+          twoFishMock.eat("blue fish")
+        }
+      }
+
+      def `test that should succeed nice`: Unit = {
+        class OneFish {
+          def eat(food: String): Unit = ()
+          def burp(flavor: String): Unit = ()
+        }
+        class TwoFish {
+          def eat(food: String): Unit = ()
+        }
+        val oneFishMock = niceMock[OneFish]
+        val twoFishMock = niceMock[TwoFish]
+
+        expecting {
+          oneFishMock.eat("red fish")
+          twoFishMock.eat("blue fish")
+        }
+
+        whenExecuting(oneFishMock, twoFishMock) {
+          oneFishMock.eat("red fish")
+          oneFishMock.burp("red fish")
+          twoFishMock.eat("blue fish")
+        }
+      }
+
+      def `test that should fail nice`: Unit = {
+        class OneFish {
+          def eat(food: String): Unit = ()
+          def burp(flavor: String): Unit = ()
+        }
+        class TwoFish {
+          def eat(food: String): Unit = ()
+        }
+        val oneFishMock = niceMock[OneFish]
+        val twoFishMock = niceMock[TwoFish]
+
+        expecting {
+          oneFishMock.eat("red fish")
+          oneFishMock.burp("red fish")
+          twoFishMock.eat("blue fish")
+        }
+
+        whenExecuting(oneFishMock, twoFishMock) {
+          oneFishMock.eat("red fish")
+          twoFishMock.eat("blue fish")
+        }
+      }
+    }
+    val rep = new EventRecordingReporter
+    a.run(None, Args(rep))
+    val tf = rep.testFailedEventsReceived
+    tf.size should === (4)
+    val ts = rep.testSucceededEventsReceived
+    ts.size should === (4)
+  }
+
+  it should "work with multiple mocks passed in as an implicit Seq" in {
+    val a = new RefSpec with EasyMockSugar {
+      def `test that should fail`: Unit = {
+        trait OneFish {
+          def eat(food: String): Unit = ()
+        }
+        trait TwoFish {
+          def eat(food: String): Unit = ()
+        }
+        val oneFishMock = mock[OneFish]
+        val twoFishMock = mock[TwoFish]
+
+        expecting {
+          oneFishMock.eat("red fish")
+          twoFishMock.eat("blue fish")
+        }
+
+        implicit val mocks = MockObjects(oneFishMock, twoFishMock)
+
+        whenExecuting {
+          oneFishMock.eat("red fish")
+          twoFishMock.eat("green fish")
+        }
+      }
+
+      def `test that should succeed`: Unit = {
+        trait OneFish {
+          def eat(food: String): Unit = ()
+        }
+        trait TwoFish {
+          def eat(food: String): Unit = ()
+        }
+        val oneFishMock = mock[OneFish]
+        val twoFishMock = mock[TwoFish]
+
+        expecting {
+          oneFishMock.eat("red fish")
+          twoFishMock.eat("blue fish")
+        }
+
+        implicit val mocks = MockObjects(oneFishMock, twoFishMock)
+
+        whenExecuting {
+          oneFishMock.eat("red fish")
+          twoFishMock.eat("blue fish")
+        }
+      }
+
+      def `test that should fail with class`: Unit = {
+        class OneFish {
+          def eat(food: String): Unit = ()
+        }
+        class TwoFish {
+          def eat(food: String): Unit = ()
+        }
+        val oneFishMock = mock[OneFish]
+        val twoFishMock = mock[TwoFish]
+
+        expecting {
+          oneFishMock.eat("red fish")
+          twoFishMock.eat("blue fish")
+        }
+
+        implicit val mocks = MockObjects(oneFishMock, twoFishMock)
+
+        whenExecuting {
+          oneFishMock.eat("red fish")
+          twoFishMock.eat("green fish")
+        }
+      }
+
+      def `test that should succeed with class`: Unit = {
+        class OneFish {
+          def eat(food: String): Unit = ()
+        }
+        class TwoFish {
+          def eat(food: String): Unit = ()
+        }
+        val oneFishMock = mock[OneFish]
+        val twoFishMock = mock[TwoFish]
+
+        expecting {
+          oneFishMock.eat("red fish")
+          twoFishMock.eat("blue fish")
+        }
+
+        implicit val mocks = MockObjects(oneFishMock, twoFishMock)
+
+        whenExecuting {
+          oneFishMock.eat("red fish")
+          twoFishMock.eat("blue fish")
+        }
+      }
+
+      def `test that should fail strict`: Unit = {
+        class OneFish {
+          def eat(food: String): Unit = ()
+          def burp(flavor: String): Unit = ()
+        }
+        class TwoFish {
+          def eat(food: String): Unit = ()
+        }
+        val oneFishMock = strictMock[OneFish]
+        val twoFishMock = strictMock[TwoFish]
+
+        expecting {
+          oneFishMock.eat("red fish")
+          oneFishMock.burp("red fish")
+          twoFishMock.eat("blue fish")
+        }
+
+        implicit val mocks = MockObjects(oneFishMock, twoFishMock)
+
+        whenExecuting {
+          oneFishMock.burp("red fish")
+          oneFishMock.eat("red fish")
+          twoFishMock.eat("blue fish")
+        }
+      }
+
+      def `test that should succeed strict`: Unit = {
+        class OneFish {
+          def eat(food: String): Unit = ()
+          def burp(flavor: String): Unit = ()
+        }
+        class TwoFish {
+          def eat(food: String): Unit = ()
+        }
+        val oneFishMock = strictMock[OneFish]
+        val twoFishMock = strictMock[TwoFish]
+
+        expecting {
+          oneFishMock.eat("red fish")
+          oneFishMock.burp("red fish")
+          twoFishMock.eat("blue fish")
+        }
+
+        implicit val mocks = MockObjects(oneFishMock, twoFishMock)
+
+        whenExecuting {
+          oneFishMock.eat("red fish")
+          oneFishMock.burp("red fish")
+          twoFishMock.eat("blue fish")
+        }
+      }
+
+      def `test that should succeed nice`: Unit = {
+        class OneFish {
+          def eat(food: String): Unit = ()
+          def burp(flavor: String): Unit = ()
+        }
+        class TwoFish {
+          def eat(food: String): Unit = ()
+        }
+        val oneFishMock = niceMock[OneFish]
+        val twoFishMock = niceMock[TwoFish]
+
+        expecting {
+          oneFishMock.eat("red fish")
+          twoFishMock.eat("blue fish")
+        }
+
+        implicit val mocks = MockObjects(oneFishMock, twoFishMock)
+
+        whenExecuting {
+          oneFishMock.eat("red fish")
+          oneFishMock.burp("red fish")
+          twoFishMock.eat("blue fish")
+        }
+      }
+
+      def `test that should fail nice`: Unit = {
+        class OneFish {
+          def eat(food: String): Unit = ()
+          def burp(flavor: String): Unit = ()
+        }
+        class TwoFish {
+          def eat(food: String): Unit = ()
+        }
+        val oneFishMock = niceMock[OneFish]
+        val twoFishMock = niceMock[TwoFish]
+
+        expecting {
+          oneFishMock.eat("red fish")
+          oneFishMock.burp("red fish")
+          twoFishMock.eat("blue fish")
+        }
+
+        implicit val mocks = MockObjects(oneFishMock, twoFishMock)
+
+        whenExecuting {
+          oneFishMock.eat("red fish")
+          twoFishMock.eat("blue fish")
+        }
+      }
+    }
+    val rep = new EventRecordingReporter
+    a.run(None, Args(rep))
+    val tf = rep.testFailedEventsReceived
+    tf.size should === (4)
+    val ts = rep.testSucceededEventsReceived
+    ts.size should === (4)
+  }
+}

--- a/src/test/scala/org/scalatestplus/easymock/EventRecorderReporter.scala
+++ b/src/test/scala/org/scalatestplus/easymock/EventRecorderReporter.scala
@@ -1,0 +1,192 @@
+package org.scalatestplus.easymock
+
+import org.scalatest.{Args, Reporter, Suite}
+import org.scalatest.events._
+
+class EventRecordingReporter extends Reporter {
+  private var eventList: List[Event] = List()
+  def eventsReceived = synchronized { eventList.reverse }
+  def testSucceededEventsReceived: List[TestSucceeded] = {
+    synchronized {
+      eventsReceived filter {
+        case event: TestSucceeded => true
+        case _ => false
+      } map {
+        case event: TestSucceeded => event
+        case _ => throw new RuntimeException("should never happen")
+      }
+    }
+  }
+  def testStartingEventsReceived: List[TestStarting] = {
+    synchronized {
+      eventsReceived filter {
+        case event: TestStarting => true
+        case _ => false
+      } map {
+        case event: TestStarting => event
+        case _ => throw new RuntimeException("should never happen")
+      }
+    }
+  }
+  // Why doesn't this work:
+  // for (event: TestSucceeded <- eventsReceived) yield event
+  def infoProvidedEventsReceived: List[InfoProvided] = {
+    synchronized {
+      eventsReceived filter {
+        case event: InfoProvided => true
+        case _ => false
+      } map {
+        case event: InfoProvided => event
+        case _ => throw new RuntimeException("should never happen")
+      }
+    }
+  }
+  def noteProvidedEventsReceived: List[NoteProvided] = {
+    synchronized {
+      eventsReceived filter {
+        case event: NoteProvided => true
+        case _ => false
+      } map {
+        case event: NoteProvided => event
+        case _ => throw new RuntimeException("should never happen")
+      }
+    }
+  }
+  def alertProvidedEventsReceived: List[AlertProvided] = {
+    synchronized {
+      eventsReceived filter {
+        case event: AlertProvided => true
+        case _ => false
+      } map {
+        case event: AlertProvided => event
+        case _ => throw new RuntimeException("should never happen")
+      }
+    }
+  }
+  def markupProvidedEventsReceived: List[MarkupProvided] = {
+    synchronized {
+      eventsReceived filter {
+        case event: MarkupProvided => true
+        case _ => false
+      } map {
+        case event: MarkupProvided => event
+        case _ => throw new RuntimeException("should never happen")
+      }
+    }
+  }
+  def scopeOpenedEventsReceived: List[ScopeOpened] = {
+    synchronized {
+      eventsReceived filter {
+        case event: ScopeOpened => true
+        case _ => false
+      } map {
+        case event: ScopeOpened => event
+        case _ => throw new RuntimeException("should never happen")
+      }
+    }
+  }
+  def scopeClosedEventsReceived: List[ScopeClosed] = {
+    synchronized {
+      eventsReceived filter {
+        case event: ScopeClosed => true
+        case _ => false
+      } map {
+        case event: ScopeClosed => event
+        case _ => throw new RuntimeException("should never happen")
+      }
+    }
+  }
+  def scopePendingEventsReceived: List[ScopePending] = {
+    synchronized {
+      eventsReceived filter {
+        case event: ScopePending => true
+        case _ => false
+      } map {
+        case event: ScopePending => event
+        case _ => throw new RuntimeException("should never happen")
+      }
+    }
+  }
+  def testPendingEventsReceived: List[TestPending] = {
+    synchronized {
+      eventsReceived filter {
+        case event: TestPending => true
+        case _ => false
+      } map {
+        case event: TestPending => event
+        case _ => throw new RuntimeException("should never happen")
+      }
+    }
+  }
+  def testCanceledEventsReceived: List[TestCanceled] = {
+    synchronized {
+      eventsReceived filter {
+        case event: TestCanceled => true
+        case _ => false
+      } map {
+        case event: TestCanceled => event
+        case _ => throw new RuntimeException("should never happen")
+      }
+    }
+  }
+  def testFailedEventsReceived: List[TestFailed] = {
+    synchronized {
+      eventsReceived filter {
+        case event: TestFailed => true
+        case _ => false
+      } map {
+        case event: TestFailed => event
+        case _ => throw new RuntimeException("should never happen")
+      }
+    }
+  }
+  def testIgnoredEventsReceived: List[TestIgnored] = {
+    synchronized {
+      eventsReceived filter {
+        case event: TestIgnored => true
+        case _ => false
+      } map {
+        case event: TestIgnored => event
+        case _ => throw new RuntimeException("should never happen")
+      }
+    }
+  }
+  def suiteStartingEventsReceived: List[SuiteStarting] = {
+    synchronized {
+      eventsReceived filter {
+        case event: SuiteStarting => true
+        case _ => false
+      } map {
+        case event: SuiteStarting => event
+        case _ => throw new RuntimeException("should never happen")
+      }
+    }
+  }
+  def suiteCompletedEventsReceived: List[SuiteCompleted] = {
+    synchronized {
+      eventsReceived filter {
+        case event: SuiteCompleted => true
+        case _ => false
+      } map {
+        case event: SuiteCompleted => event
+        case _ => throw new RuntimeException("should never happen")
+      }
+    }
+  }
+  def suiteAbortedEventsReceived: List[SuiteAborted] = {
+    synchronized {
+      eventsReceived filter {
+        case event: SuiteAborted => true
+        case _ => false
+      } map {
+        case event: SuiteAborted => event
+        case _ => throw new RuntimeException("should never happen")
+      }
+    }
+  }
+  def apply(event: Event): Unit = {
+    synchronized {
+      eventList ::= event
+    }
+  }
+}


### PR DESCRIPTION
Moving over easymock integration code from current 3.1.x branch in ScalaTest.