### PR TITLE
[3.1.0.x] Build Update

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,6 +32,22 @@ libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "3.1.0-RC3"
 )
 
+import scala.xml.{Node => XmlNode, NodeSeq => XmlNodeSeq, _}
+import scala.xml.transform.{RewriteRule, RuleTransformer}
+
+// skip dependency elements with a scope
+pomPostProcess := { (node: XmlNode) =>
+  new RuleTransformer(new RewriteRule {
+    override def transform(node: XmlNode): XmlNodeSeq = node match {
+      case e: Elem if e.label == "dependency"
+          && e.child.exists(child => child.label == "scope") =>
+        def txt(label: String): String = "\"" + e.child.filter(_.label == label).flatMap(_.text).mkString + "\""
+        Comment(s""" scoped dependency ${txt("groupId")} % ${txt("artifactId")} % ${txt("version")} % ${txt("scope")} has been omitted """)
+      case _ => node
+    }
+  }).transform(node).head
+}
+
 enablePlugins(SbtOsgi)
 
 osgiSettings

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "easymock-3.2"
 
 organization := "org.scalatestplus"
 
-version := "3.1.0.0-RC3"
+version := "3.1.0.1"
 
 homepage := Some(url("https://github.com/scalatest/scalatestplus-easymock"))
 
@@ -23,13 +23,13 @@ developers := List(
   )
 )
 
-crossScalaVersions := List("2.10.7", "2.11.12", "2.12.10", "2.13.0")
+crossScalaVersions := List("2.10.7", "2.11.12", "2.12.10", "2.13.1")
 
 resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"
 
 libraryDependencies ++= Seq(
   "org.easymock" % "easymockclassextension" % "3.2",
-  "org.scalatest" %% "scalatest" % "3.1.0-RC3"
+  "org.scalatest" %% "scalatest" % "3.1.0"
 )
 
 import scala.xml.{Node => XmlNode, NodeSeq => XmlNodeSeq, _}


### PR DESCRIPTION
- Cherry-picked build fix for test dependency scope from master (https://github.com/scalatest/scalatestplus-easymock/commit/bef67dc98f6b58f1dadf64b91f6393c1093402a6)
- Updated scala versions and use scalatest 3.1.0.