### PR TITLE
3.3.0.0-SNAP3

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 
  **Usage**
 
-To use it for ScalaTest 3.1.0 and EasyMock 3.2.x: 
+To use it for ScalaTest 3.3.0-SNAP3 and EasyMock 3.3.x: 
 
 SBT: 
 
 ```
-libraryDependencies += "org.scalatestplus" %% "easymock-3-2" % "3.1.0.0" % "test"
+libraryDependencies += "org.scalatestplus" %% "easymock-3-2" % "3.3.0.0-SNAP3" % "test"
 ```
 
 Maven: 
@@ -17,7 +17,7 @@ Maven:
 <dependency>
   <groupId>org.scalatestplus</groupId>
   <artifactId>easymock-3-2</artifactId>
-  <version>3.1.0.0</version>
+  <version>3.3.0.0-SNAP3</version>
   <scope>test</scope>
 </dependency>
 ```

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "easymock-3.2"
 
 organization := "org.scalatestplus"
 
-version := "3.3.0.0-SNAP2"
+version := "3.3.0.0-SNAP3"
 
 homepage := Some(url("https://github.com/scalatest/scalatestplus-easymock"))
 
@@ -23,16 +23,16 @@ developers := List(
   )
 )
 
-crossScalaVersions := List("2.10.7", "2.11.12", "2.12.10", "2.13.1")
+crossScalaVersions := List("2.10.7", "2.11.12", "2.12.11", "2.13.2")
 
 resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"
 
 libraryDependencies ++= Seq(
   "org.easymock" % "easymockclassextension" % "3.2",
-  "org.scalatest" %% "scalatest-core" % "3.3.0-SNAP2", 
-  "org.scalatest" %% "scalatest-refspec" % "3.3.0-SNAP2" % "test", 
-  "org.scalatest" %% "scalatest-flatspec" % "3.3.0-SNAP2" % "test", 
-  "org.scalatest" %% "scalatest-shouldmatchers" % "3.3.0-SNAP2" % "test"
+  "org.scalatest" %% "scalatest-core" % "3.3.0-SNAP3", 
+  "org.scalatest" %% "scalatest-refspec" % "3.3.0-SNAP3" % "test", 
+  "org.scalatest" %% "scalatest-flatspec" % "3.3.0-SNAP3" % "test", 
+  "org.scalatest" %% "scalatest-shouldmatchers" % "3.3.0-SNAP3" % "test"
 )
 
 import scala.xml.{Node => XmlNode, NodeSeq => XmlNodeSeq, _}


### PR DESCRIPTION
Pulled changes from 3.2 branch and updated to release for ScalaTest 3.3.0-SNAP3.